### PR TITLE
use more specfic permissions

### DIFF
--- a/class-support-access-manager.php
+++ b/class-support-access-manager.php
@@ -400,7 +400,7 @@ if ( ! class_exists( 'Support_Access_Manager' ) ) {
 		 * Handle form submission and create the temp admin user.
 		 */
 		public function handle_access_form_submission() {
-			if ( ! isset( $_POST['access_duration'] ) || ! current_user_can( 'manage_options' ) ) {
+			if ( ! isset( $_POST['access_duration'] ) || ! current_user_can( 'create_users' ) ) {
 				return;
 			}
 


### PR DESCRIPTION
The cap required in WP core to create users is `create_users` (admin only), not `manage_options`